### PR TITLE
Fix table creation 404 error by removing trailingSlash config

### DIFF
--- a/apps/poker-frontend/next.config.ts
+++ b/apps/poker-frontend/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
-  trailingSlash: true,
+  // Remove trailingSlash to fix 404 issues with dynamic routes in production
   images: {
     unoptimized: true
   },


### PR DESCRIPTION
Fixes #2

This PR fixes the 404 error that occurs when creating tables on the production app.

**Root Cause**: The `trailingSlash: true` configuration in Next.js was causing dynamic routes (`/game/[tableId]`) to return 404 errors in production on Cloudflare Pages.

**Changes**:
- Removed `trailingSlash: true` from `apps/poker-frontend/next.config.ts`
- Dynamic routes now work correctly in production

Generated with [Claude Code](https://claude.ai/code)