### PR TITLE
feat(security): implement idempotency keys for wallet transactions

### DIFF
--- a/packages/api/src/__tests__/idempotency.test.ts
+++ b/packages/api/src/__tests__/idempotency.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Idempotency Tests
+ * 
+ * Tests for idempotency key support in wallet transactions
+ */
+
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { WalletRoutes } from '../routes/wallet-routes';
+import { IdempotencyService } from '../services/idempotency-service';
+import { WalletManager } from '@primo-poker/persistence';
+import { RandomUtils } from '@primo-poker/shared';
+
+// Mock dependencies
+jest.mock('@primo-poker/persistence');
+jest.mock('@primo-poker/core', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+describe('Idempotency Tests', () => {
+  let walletRoutes: WalletRoutes;
+  let mockEnv: any;
+  let mockKV: any;
+  let mockRequest: any;
+
+  beforeEach(() => {
+    // Mock KV storage
+    mockKV = {
+      get: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn(),
+      list: jest.fn(),
+    };
+
+    // Mock environment
+    mockEnv = {
+      KV: mockKV,
+      JWT_SECRET: 'test-secret',
+    };
+
+    // Mock authenticated request
+    mockRequest = {
+      user: { userId: 'test-user-123', username: 'testuser' },
+      env: mockEnv,
+      rateLimitInfo: {
+        limit: 100,
+        remaining: 99,
+        reset: Date.now() + 3600000,
+      },
+      headers: new Map([
+        ['Content-Type', 'application/json'],
+      ]),
+      url: 'https://api.example.com/api/wallet/deposit',
+      method: 'POST',
+      json: jest.fn(),
+    };
+
+    // Create instance
+    walletRoutes = new WalletRoutes();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Deposit Idempotency', () => {
+    it('should process deposit successfully without idempotency key', async () => {
+      const depositData = {
+        amount: 100,
+        method: 'credit_card'
+      };
+
+      mockRequest.json.mockResolvedValue(depositData);
+
+      const mockWalletManager = WalletManager as jest.MockedClass<typeof WalletManager>;
+      mockWalletManager.prototype.deposit.mockResolvedValue({
+        success: true,
+        newBalance: 1100,
+        transactionId: 'txn-123'
+      });
+
+      const router = walletRoutes.getRouter();
+      const handler = router.routes.find(r => r.path === '/deposit' && r.method === 'POST')?.handler;
+      const response = await handler?.(mockRequest);
+
+      expect(response?.status).toBe(200);
+      const body = await response?.json();
+      expect(body.success).toBe(true);
+      expect(body.data.newBalance).toBe(1100);
+    });
+
+    it('should return cached response for duplicate idempotency key', async () => {
+      const idempotencyKey = 'test-idempotency-key-123';
+      const depositData = {
+        amount: 100,
+        method: 'credit_card',
+        idempotencyKey
+      };
+
+      const cachedResponse = {
+        success: true,
+        newBalance: 1100,
+        transactionId: 'txn-cached-123'
+      };
+
+      // Mock idempotency record exists
+      mockKV.get.mockResolvedValue(JSON.stringify({
+        key: idempotencyKey,
+        userId: 'test-user-123',
+        action: 'deposit',
+        requestHash: 'hash123',
+        response: cachedResponse,
+        status: 'completed',
+        createdAt: new Date(),
+        expiresAt: new Date(Date.now() + 86400000)
+      }));
+
+      mockRequest.json.mockResolvedValue(depositData);
+
+      const router = walletRoutes.getRouter();
+      const handler = router.routes.find(r => r.path === '/deposit' && r.method === 'POST')?.handler;
+      const response = await handler?.(mockRequest);
+
+      expect(response?.status).toBe(200);
+      const body = await response?.json();
+      expect(body.success).toBe(true);
+      expect(body.data).toEqual(cachedResponse);
+      
+      // Verify wallet manager was not called
+      const mockWalletManager = WalletManager as jest.MockedClass<typeof WalletManager>;
+      expect(mockWalletManager.prototype.deposit).not.toHaveBeenCalled();
+    });
+
+    it('should validate request hash when enabled', async () => {
+      const idempotencyKey = 'test-idempotency-key-456';
+      const originalData = {
+        amount: 100,
+        method: 'credit_card',
+        idempotencyKey
+      };
+
+      const modifiedData = {
+        amount: 200, // Different amount
+        method: 'credit_card',
+        idempotencyKey
+      };
+
+      // Mock idempotency record with different hash
+      mockKV.get.mockResolvedValue(JSON.stringify({
+        key: idempotencyKey,
+        userId: 'test-user-123',
+        action: 'deposit',
+        requestHash: 'original-hash',
+        response: { success: true },
+        status: 'completed',
+        createdAt: new Date(),
+        expiresAt: new Date(Date.now() + 86400000)
+      }));
+
+      mockRequest.json.mockResolvedValue(modifiedData);
+
+      // Create service with hash validation enabled
+      const idempotencyService = new IdempotencyService(mockKV, {
+        enableHashValidation: true
+      });
+
+      const result = await idempotencyService.checkIdempotency(
+        idempotencyKey,
+        'test-user-123',
+        'deposit',
+        modifiedData
+      );
+
+      expect(result.exists).toBe(true);
+      expect(result.record?.status).toBe('failed');
+      expect(result.record?.response.error).toContain('does not match original request');
+    });
+
+    it('should handle expired idempotency keys', async () => {
+      const idempotencyKey = 'test-expired-key';
+      const depositData = {
+        amount: 100,
+        method: 'credit_card',
+        idempotencyKey
+      };
+
+      // Mock expired idempotency record
+      mockKV.get.mockResolvedValue(JSON.stringify({
+        key: idempotencyKey,
+        userId: 'test-user-123',
+        action: 'deposit',
+        requestHash: 'hash123',
+        response: { success: true },
+        status: 'completed',
+        createdAt: new Date(Date.now() - 90000000), // Created 25 hours ago
+        expiresAt: new Date(Date.now() - 3600000) // Expired 1 hour ago
+      }));
+
+      mockRequest.json.mockResolvedValue(depositData);
+
+      const mockWalletManager = WalletManager as jest.MockedClass<typeof WalletManager>;
+      mockWalletManager.prototype.deposit.mockResolvedValue({
+        success: true,
+        newBalance: 1100,
+        transactionId: 'txn-new-123'
+      });
+
+      const router = walletRoutes.getRouter();
+      const handler = router.routes.find(r => r.path === '/deposit' && r.method === 'POST')?.handler;
+      const response = await handler?.(mockRequest);
+
+      expect(response?.status).toBe(200);
+      const body = await response?.json();
+      expect(body.success).toBe(true);
+      expect(body.data.transactionId).toBe('txn-new-123');
+      
+      // Verify expired key was deleted
+      expect(mockKV.delete).toHaveBeenCalledWith(expect.stringContaining('test-expired-key'));
+    });
+
+    it('should store failed responses for idempotency', async () => {
+      const idempotencyKey = 'test-failed-key';
+      const depositData = {
+        amount: 100,
+        method: 'credit_card',
+        idempotencyKey
+      };
+
+      mockRequest.json.mockResolvedValue(depositData);
+      mockKV.get.mockResolvedValue(null); // No existing record
+
+      const mockWalletManager = WalletManager as jest.MockedClass<typeof WalletManager>;
+      mockWalletManager.prototype.deposit.mockResolvedValue({
+        success: false,
+        error: 'Insufficient funds'
+      });
+
+      const router = walletRoutes.getRouter();
+      const handler = router.routes.find(r => r.path === '/deposit' && r.method === 'POST')?.handler;
+      const response = await handler?.(mockRequest);
+
+      expect(response?.status).toBe(400);
+      const body = await response?.json();
+      expect(body.success).toBe(false);
+      expect(body.error.message).toBe('Insufficient funds');
+
+      // Verify failed response was stored
+      expect(mockKV.put).toHaveBeenCalledWith(
+        expect.stringContaining(idempotencyKey),
+        expect.stringContaining('"status":"failed"'),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('Withdrawal Idempotency', () => {
+    it('should handle withdrawal with idempotency', async () => {
+      const idempotencyKey = 'withdraw-key-123';
+      const withdrawData = {
+        amount: 50,
+        method: 'bank',
+        idempotencyKey
+      };
+
+      mockRequest.json.mockResolvedValue(withdrawData);
+      mockKV.get.mockResolvedValue(null); // No existing record
+
+      const mockWalletManager = WalletManager as jest.MockedClass<typeof WalletManager>;
+      mockWalletManager.prototype.withdraw.mockResolvedValue({
+        success: true,
+        newBalance: 950,
+        transactionId: 'txn-withdraw-123'
+      });
+      mockWalletManager.prototype.getWallet.mockResolvedValue({
+        playerId: 'test-user-123',
+        balance: 950,
+        currency: 'USD',
+        frozen: 0,
+        lastUpdated: new Date()
+      });
+
+      const router = walletRoutes.getRouter();
+      const handler = router.routes.find(r => r.path === '/withdraw' && r.method === 'POST')?.handler;
+      const response = await handler?.(mockRequest);
+
+      expect(response?.status).toBe(200);
+      const body = await response?.json();
+      expect(body.success).toBe(true);
+      expect(body.data.newBalance).toBe(950);
+
+      // Verify idempotency key was stored
+      expect(mockKV.put).toHaveBeenCalledWith(
+        expect.stringContaining(idempotencyKey),
+        expect.any(String),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('Transfer Idempotency', () => {
+    it('should handle transfer with idempotency', async () => {
+      const idempotencyKey = 'transfer-key-123';
+      const transferData = {
+        to_table_id: 'table-456',
+        amount: 200,
+        idempotencyKey
+      };
+
+      mockRequest.json.mockResolvedValue(transferData);
+      mockKV.get.mockResolvedValue(null); // No existing record
+
+      const mockWalletManager = WalletManager as jest.MockedClass<typeof WalletManager>;
+      mockWalletManager.prototype.transfer.mockResolvedValue({
+        success: true,
+        newBalance: 800,
+        transferredAmount: 200,
+        transactionId: 'txn-transfer-123'
+      });
+
+      const router = walletRoutes.getRouter();
+      const handler = router.routes.find(r => r.path === '/transfer' && r.method === 'POST')?.handler;
+      const response = await handler?.(mockRequest);
+
+      expect(response?.status).toBe(200);
+      const body = await response?.json();
+      expect(body.success).toBe(true);
+      expect(body.data.transferredAmount).toBe(200);
+    });
+  });
+
+  describe('Buy-in Idempotency', () => {
+    it('should handle buy-in with idempotency', async () => {
+      const idempotencyKey = 'buyin-key-123';
+      const buyInData = {
+        tableId: 'table-789',
+        amount: 100,
+        idempotencyKey
+      };
+
+      mockRequest.json.mockResolvedValue(buyInData);
+      mockKV.get.mockResolvedValue(null); // No existing record
+
+      const mockWalletManager = WalletManager as jest.MockedClass<typeof WalletManager>;
+      mockWalletManager.prototype.processBuyIn.mockResolvedValue({
+        success: true,
+        chipCount: 100,
+        walletBalance: 900
+      });
+
+      const router = walletRoutes.getRouter();
+      const handler = router.routes.find(r => r.path === '/buyin' && r.method === 'POST')?.handler;
+      const response = await handler?.(mockRequest);
+
+      expect(response?.status).toBe(200);
+      const body = await response?.json();
+      expect(body.success).toBe(true);
+      expect(body.data.chipCount).toBe(100);
+    });
+  });
+
+  describe('Cash-out Idempotency', () => {
+    it('should handle cash-out with idempotency', async () => {
+      const idempotencyKey = 'cashout-key-123';
+      const cashOutData = {
+        tableId: 'table-789',
+        chipAmount: 150,
+        idempotencyKey
+      };
+
+      mockRequest.json.mockResolvedValue(cashOutData);
+      mockKV.get.mockResolvedValue(null); // No existing record
+
+      const mockWalletManager = WalletManager as jest.MockedClass<typeof WalletManager>;
+      mockWalletManager.prototype.processCashOut.mockResolvedValue(undefined);
+      mockWalletManager.prototype.getWallet.mockResolvedValue({
+        playerId: 'test-user-123',
+        balance: 1150,
+        currency: 'USD',
+        frozen: 0,
+        lastUpdated: new Date()
+      });
+
+      const router = walletRoutes.getRouter();
+      const handler = router.routes.find(r => r.path === '/cashout' && r.method === 'POST')?.handler;
+      const response = await handler?.(mockRequest);
+
+      expect(response?.status).toBe(200);
+      const body = await response?.json();
+      expect(body.success).toBe(true);
+      expect(body.data.cashedOut).toBe(150);
+    });
+  });
+
+  describe('IdempotencyService', () => {
+    it('should generate consistent request hashes', () => {
+      const service = new IdempotencyService(mockKV);
+      const requestBody1 = { amount: 100, method: 'credit_card', extra: { nested: true } };
+      const requestBody2 = { extra: { nested: true }, amount: 100, method: 'credit_card' }; // Different order
+
+      const hash1 = service['generateRequestHash'](requestBody1);
+      const hash2 = service['generateRequestHash'](requestBody2);
+
+      expect(hash1).toBe(hash2); // Should be same despite different key order
+    });
+
+    it('should handle concurrent requests with same idempotency key', async () => {
+      const idempotencyKey = 'concurrent-key';
+      const service = new IdempotencyService(mockKV);
+
+      // First request stores pending
+      mockKV.get.mockResolvedValueOnce(null);
+      await service.storePendingRequest(idempotencyKey, 'user-1', 'deposit', { amount: 100 });
+
+      // Second request finds pending
+      mockKV.get.mockResolvedValueOnce(JSON.stringify({
+        key: idempotencyKey,
+        userId: 'user-1',
+        action: 'deposit',
+        requestHash: 'hash',
+        response: null,
+        status: 'pending',
+        createdAt: new Date(),
+        expiresAt: new Date(Date.now() + 86400000)
+      }));
+
+      const result = await service.checkIdempotency(idempotencyKey, 'user-1', 'deposit', { amount: 100 });
+      expect(result.exists).toBe(true);
+      expect(result.record?.status).toBe('pending');
+    });
+  });
+});

--- a/packages/api/src/services/__tests__/idempotency-service.test.ts
+++ b/packages/api/src/services/__tests__/idempotency-service.test.ts
@@ -1,0 +1,332 @@
+/**
+ * IdempotencyService Unit Tests
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { IdempotencyService } from '../idempotency-service';
+import { IdempotencyRecord } from '@primo-poker/shared';
+
+describe('IdempotencyService', () => {
+  let service: IdempotencyService;
+  let mockKV: any;
+
+  beforeEach(() => {
+    mockKV = {
+      get: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn(),
+      list: jest.fn(() => ({ keys: [] })),
+    };
+
+    service = new IdempotencyService(mockKV, {
+      ttlSeconds: 3600, // 1 hour for testing
+      enableHashValidation: true
+    });
+  });
+
+  describe('checkIdempotency', () => {
+    it('should return exists: false for non-existent key', async () => {
+      mockKV.get.mockResolvedValue(null);
+
+      const result = await service.checkIdempotency(
+        'new-key',
+        'user-123',
+        'deposit',
+        { amount: 100 }
+      );
+
+      expect(result.exists).toBe(false);
+      expect(result.record).toBeUndefined();
+    });
+
+    it('should return exists: true with record for existing key', async () => {
+      const existingRecord: IdempotencyRecord = {
+        key: 'existing-key',
+        userId: 'user-123',
+        action: 'deposit',
+        requestHash: 'hash123',
+        response: { success: true, balance: 1000 },
+        status: 'completed',
+        createdAt: new Date(),
+        expiresAt: new Date(Date.now() + 3600000)
+      };
+
+      mockKV.get.mockResolvedValue(JSON.stringify(existingRecord));
+
+      const result = await service.checkIdempotency(
+        'existing-key',
+        'user-123',
+        'deposit',
+        { amount: 100 }
+      );
+
+      expect(result.exists).toBe(true);
+      expect(result.record).toEqual(existingRecord);
+    });
+
+    it('should delete and return exists: false for expired key', async () => {
+      const expiredRecord: IdempotencyRecord = {
+        key: 'expired-key',
+        userId: 'user-123',
+        action: 'deposit',
+        requestHash: 'hash123',
+        response: { success: true },
+        status: 'completed',
+        createdAt: new Date(Date.now() - 7200000), // 2 hours ago
+        expiresAt: new Date(Date.now() - 3600000) // 1 hour ago
+      };
+
+      mockKV.get.mockResolvedValue(JSON.stringify(expiredRecord));
+
+      const result = await service.checkIdempotency(
+        'expired-key',
+        'user-123',
+        'deposit',
+        { amount: 100 }
+      );
+
+      expect(result.exists).toBe(false);
+      expect(mockKV.delete).toHaveBeenCalledWith('idempotency:user-123:expired-key');
+    });
+
+    it('should validate request hash when enabled', async () => {
+      const existingRecord: IdempotencyRecord = {
+        key: 'hash-key',
+        userId: 'user-123',
+        action: 'deposit',
+        requestHash: service['generateRequestHash']({ amount: 100 }),
+        response: { success: true },
+        status: 'completed',
+        createdAt: new Date(),
+        expiresAt: new Date(Date.now() + 3600000)
+      };
+
+      mockKV.get.mockResolvedValue(JSON.stringify(existingRecord));
+
+      // Different request body
+      const result = await service.checkIdempotency(
+        'hash-key',
+        'user-123',
+        'deposit',
+        { amount: 200 } // Different amount
+      );
+
+      expect(result.exists).toBe(true);
+      expect(result.record?.status).toBe('failed');
+      expect(result.record?.response.error).toContain('does not match original request');
+    });
+
+    it('should handle KV errors gracefully', async () => {
+      mockKV.get.mockRejectedValue(new Error('KV error'));
+
+      const result = await service.checkIdempotency(
+        'error-key',
+        'user-123',
+        'deposit',
+        { amount: 100 }
+      );
+
+      expect(result.exists).toBe(false);
+      expect(result.record).toBeUndefined();
+    });
+  });
+
+  describe('storePendingRequest', () => {
+    it('should store pending request with correct TTL', async () => {
+      await service.storePendingRequest(
+        'pending-key',
+        'user-123',
+        'withdraw',
+        { amount: 50 }
+      );
+
+      expect(mockKV.put).toHaveBeenCalledWith(
+        'idempotency:user-123:pending-key',
+        expect.stringContaining('"status":"pending"'),
+        { expirationTtl: 3600 }
+      );
+    });
+
+    it('should handle storage errors gracefully', async () => {
+      mockKV.put.mockRejectedValue(new Error('Storage error'));
+
+      // Should not throw
+      await expect(
+        service.storePendingRequest('error-key', 'user-123', 'deposit', {})
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('storeCompletedResponse', () => {
+    it('should update existing record with response', async () => {
+      const existingRecord: IdempotencyRecord = {
+        key: 'update-key',
+        userId: 'user-123',
+        action: 'deposit',
+        requestHash: 'hash',
+        response: null,
+        status: 'pending',
+        createdAt: new Date(),
+        expiresAt: new Date(Date.now() + 3600000)
+      };
+
+      mockKV.get.mockResolvedValue(JSON.stringify(existingRecord));
+
+      await service.storeCompletedResponse(
+        'update-key',
+        'user-123',
+        { success: true, balance: 1000 },
+        'completed'
+      );
+
+      expect(mockKV.put).toHaveBeenCalledWith(
+        'idempotency:user-123:update-key',
+        expect.stringContaining('"status":"completed"'),
+        expect.any(Object)
+      );
+    });
+
+    it('should handle missing record gracefully', async () => {
+      mockKV.get.mockResolvedValue(null);
+
+      // Should not throw
+      await expect(
+        service.storeCompletedResponse('missing-key', 'user-123', {}, 'completed')
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('deleteIdempotencyKey', () => {
+    it('should delete key from storage', async () => {
+      await service.deleteIdempotencyKey('delete-key', 'user-123');
+
+      expect(mockKV.delete).toHaveBeenCalledWith('idempotency:user-123:delete-key');
+    });
+
+    it('should handle deletion errors gracefully', async () => {
+      mockKV.delete.mockRejectedValue(new Error('Delete error'));
+
+      // Should not throw
+      await expect(
+        service.deleteIdempotencyKey('error-key', 'user-123')
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('getUserIdempotencyKeys', () => {
+    it('should return user idempotency keys', async () => {
+      const keys = [
+        { name: 'idempotency:user-123:key1' },
+        { name: 'idempotency:user-123:key2' }
+      ];
+
+      const records = [
+        {
+          key: 'key1',
+          userId: 'user-123',
+          action: 'deposit',
+          requestHash: 'hash1',
+          response: { success: true },
+          status: 'completed',
+          createdAt: new Date(Date.now() - 1000),
+          expiresAt: new Date(Date.now() + 3600000)
+        },
+        {
+          key: 'key2',
+          userId: 'user-123',
+          action: 'withdraw',
+          requestHash: 'hash2',
+          response: { success: true },
+          status: 'completed',
+          createdAt: new Date(),
+          expiresAt: new Date(Date.now() + 3600000)
+        }
+      ];
+
+      mockKV.list.mockResolvedValue({ keys });
+      mockKV.get
+        .mockResolvedValueOnce(JSON.stringify(records[0]))
+        .mockResolvedValueOnce(JSON.stringify(records[1]));
+
+      const result = await service.getUserIdempotencyKeys('user-123');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].key).toBe('key2'); // Most recent first
+      expect(result[1].key).toBe('key1');
+    });
+
+    it('should filter out expired keys', async () => {
+      const keys = [
+        { name: 'idempotency:user-123:active' },
+        { name: 'idempotency:user-123:expired' }
+      ];
+
+      mockKV.list.mockResolvedValue({ keys });
+      mockKV.get
+        .mockResolvedValueOnce(JSON.stringify({
+          key: 'active',
+          userId: 'user-123',
+          action: 'deposit',
+          requestHash: 'hash1',
+          response: { success: true },
+          status: 'completed',
+          createdAt: new Date(),
+          expiresAt: new Date(Date.now() + 3600000) // Future
+        }))
+        .mockResolvedValueOnce(JSON.stringify({
+          key: 'expired',
+          userId: 'user-123',
+          action: 'withdraw',
+          requestHash: 'hash2',
+          response: { success: true },
+          status: 'completed',
+          createdAt: new Date(Date.now() - 7200000),
+          expiresAt: new Date(Date.now() - 3600000) // Past
+        }));
+
+      const result = await service.getUserIdempotencyKeys('user-123');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('active');
+    });
+  });
+
+  describe('generateRequestHash', () => {
+    it('should generate consistent hashes for same data', () => {
+      const data1 = { a: 1, b: 2, c: { d: 3 } };
+      const data2 = { c: { d: 3 }, a: 1, b: 2 }; // Different order
+
+      const hash1 = service['generateRequestHash'](data1);
+      const hash2 = service['generateRequestHash'](data2);
+
+      expect(hash1).toBe(hash2);
+    });
+
+    it('should generate different hashes for different data', () => {
+      const data1 = { amount: 100 };
+      const data2 = { amount: 200 };
+
+      const hash1 = service['generateRequestHash'](data1);
+      const hash2 = service['generateRequestHash'](data2);
+
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it('should handle arrays in request data', () => {
+      const data1 = { items: [1, 2, 3], name: 'test' };
+      const data2 = { name: 'test', items: [1, 2, 3] };
+
+      const hash1 = service['generateRequestHash'](data1);
+      const hash2 = service['generateRequestHash'](data2);
+
+      expect(hash1).toBe(hash2);
+    });
+
+    it('should handle null and undefined values', () => {
+      const data = { a: null, b: undefined, c: 'value' };
+
+      // Should not throw
+      expect(() => service['generateRequestHash'](data)).not.toThrow();
+    });
+  });
+});

--- a/packages/api/src/services/idempotency-service.ts
+++ b/packages/api/src/services/idempotency-service.ts
@@ -1,0 +1,232 @@
+/**
+ * Idempotency Service
+ * 
+ * Handles storage and validation of idempotency keys to prevent
+ * duplicate financial transactions on retries
+ */
+
+import { logger } from '@primo-poker/core';
+import { IdempotencyRecord, IdempotencyOptions } from '@primo-poker/shared';
+import crypto from 'crypto';
+
+export class IdempotencyService {
+  private readonly DEFAULT_TTL_SECONDS = 86400; // 24 hours
+  private readonly KEY_PREFIX = 'idempotency:';
+  
+  constructor(
+    private readonly kv: KVNamespace,
+    private readonly options: IdempotencyOptions = {}
+  ) {}
+
+  /**
+   * Check if an idempotency key exists and return cached response if available
+   */
+  async checkIdempotency(
+    key: string,
+    userId: string,
+    action: string,
+    requestBody: any
+  ): Promise<{ exists: boolean; record?: IdempotencyRecord }> {
+    try {
+      const storageKey = this.getStorageKey(key, userId);
+      const storedData = await this.kv.get(storageKey, 'json') as IdempotencyRecord | null;
+      
+      if (!storedData) {
+        return { exists: false };
+      }
+
+      // Check if expired
+      if (new Date(storedData.expiresAt) < new Date()) {
+        await this.kv.delete(storageKey);
+        return { exists: false };
+      }
+
+      // Validate request hash if enabled
+      if (this.options.enableHashValidation) {
+        const currentHash = this.generateRequestHash(requestBody);
+        if (currentHash !== storedData.requestHash) {
+          logger.warn('Idempotency key used with different request body', {
+            key,
+            userId,
+            action,
+            storedHash: storedData.requestHash,
+            currentHash
+          });
+          return { 
+            exists: true, 
+            record: {
+              ...storedData,
+              status: 'failed',
+              response: { 
+                error: 'Request body does not match original request for this idempotency key' 
+              }
+            }
+          };
+        }
+      }
+
+      return { exists: true, record: storedData };
+    } catch (error) {
+      logger.error('Error checking idempotency', error as Error, { key, userId, action });
+      // On error, allow request to proceed (fail open)
+      return { exists: false };
+    }
+  }
+
+  /**
+   * Store idempotency record for a pending request
+   */
+  async storePendingRequest(
+    key: string,
+    userId: string,
+    action: string,
+    requestBody: any
+  ): Promise<void> {
+    try {
+      const ttl = this.options.ttlSeconds || this.DEFAULT_TTL_SECONDS;
+      const now = new Date();
+      const expiresAt = new Date(now.getTime() + ttl * 1000);
+      
+      const record: IdempotencyRecord = {
+        key,
+        userId,
+        action,
+        requestHash: this.generateRequestHash(requestBody),
+        response: null,
+        status: 'pending',
+        createdAt: now,
+        expiresAt
+      };
+
+      const storageKey = this.getStorageKey(key, userId);
+      await this.kv.put(
+        storageKey,
+        JSON.stringify(record),
+        { expirationTtl: ttl }
+      );
+    } catch (error) {
+      logger.error('Error storing pending idempotency record', error as Error, { 
+        key, 
+        userId, 
+        action 
+      });
+      // Allow request to proceed on storage failure
+    }
+  }
+
+  /**
+   * Update idempotency record with completed response
+   */
+  async storeCompletedResponse(
+    key: string,
+    userId: string,
+    response: any,
+    status: 'completed' | 'failed'
+  ): Promise<void> {
+    try {
+      const storageKey = this.getStorageKey(key, userId);
+      const existingData = await this.kv.get(storageKey, 'json') as IdempotencyRecord | null;
+      
+      if (!existingData) {
+        logger.warn('Idempotency record not found when storing response', { key, userId });
+        return;
+      }
+
+      const ttl = this.options.ttlSeconds || this.DEFAULT_TTL_SECONDS;
+      const remainingTtl = Math.max(
+        0,
+        Math.floor((new Date(existingData.expiresAt).getTime() - Date.now()) / 1000)
+      );
+
+      const updatedRecord: IdempotencyRecord = {
+        ...existingData,
+        response,
+        status
+      };
+
+      await this.kv.put(
+        storageKey,
+        JSON.stringify(updatedRecord),
+        { expirationTtl: remainingTtl || ttl }
+      );
+    } catch (error) {
+      logger.error('Error storing completed idempotency response', error as Error, { 
+        key, 
+        userId, 
+        status 
+      });
+    }
+  }
+
+  /**
+   * Delete idempotency record (for cleanup or testing)
+   */
+  async deleteIdempotencyKey(key: string, userId: string): Promise<void> {
+    try {
+      const storageKey = this.getStorageKey(key, userId);
+      await this.kv.delete(storageKey);
+    } catch (error) {
+      logger.error('Error deleting idempotency key', error as Error, { key, userId });
+    }
+  }
+
+  /**
+   * Get all active idempotency keys for a user (for debugging/admin)
+   */
+  async getUserIdempotencyKeys(userId: string, limit: number = 100): Promise<IdempotencyRecord[]> {
+    try {
+      const prefix = `${this.KEY_PREFIX}${userId}:`;
+      const list = await this.kv.list({ prefix, limit });
+      
+      const records: IdempotencyRecord[] = [];
+      for (const key of list.keys) {
+        const record = await this.kv.get(key.name, 'json') as IdempotencyRecord | null;
+        if (record && new Date(record.expiresAt) > new Date()) {
+          records.push(record);
+        }
+      }
+      
+      return records.sort((a, b) => 
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      );
+    } catch (error) {
+      logger.error('Error getting user idempotency keys', error as Error, { userId });
+      return [];
+    }
+  }
+
+  /**
+   * Generate storage key for KV namespace
+   */
+  private getStorageKey(key: string, userId: string): string {
+    return `${this.KEY_PREFIX}${userId}:${key}`;
+  }
+
+  /**
+   * Generate hash of request body for validation
+   */
+  private generateRequestHash(requestBody: any): string {
+    const sortedBody = this.sortObject(requestBody);
+    const bodyString = JSON.stringify(sortedBody);
+    return crypto.createHash('sha256').update(bodyString).digest('hex');
+  }
+
+  /**
+   * Sort object keys recursively for consistent hashing
+   */
+  private sortObject(obj: any): any {
+    if (obj === null || typeof obj !== 'object') {
+      return obj;
+    }
+
+    if (Array.isArray(obj)) {
+      return obj.map(item => this.sortObject(item));
+    }
+
+    const sorted: any = {};
+    Object.keys(obj).sort().forEach(key => {
+      sorted[key] = this.sortObject(obj[key]);
+    });
+    return sorted;
+  }
+}

--- a/packages/api/src/validation/wallet-schemas.ts
+++ b/packages/api/src/validation/wallet-schemas.ts
@@ -9,7 +9,8 @@ export const DepositRequestSchema = z.object({
   amount: z.number().positive('Amount must be positive'),
   method: z.enum(['credit_card', 'bank'], {
     errorMap: () => ({ message: 'Invalid payment method. Must be credit_card or bank' })
-  })
+  }),
+  idempotencyKey: z.string().min(1).max(128).optional()
 });
 
 // Withdraw request schema
@@ -17,13 +18,29 @@ export const WithdrawRequestSchema = z.object({
   amount: z.number().positive('Amount must be positive'),
   method: z.enum(['bank', 'check'], {
     errorMap: () => ({ message: 'Invalid withdrawal method. Must be bank or check' })
-  })
+  }),
+  idempotencyKey: z.string().min(1).max(128).optional()
 });
 
 // Transfer request schema
 export const TransferRequestSchema = z.object({
   to_table_id: z.string().min(1, 'Table ID is required'),
-  amount: z.number().positive('Amount must be positive')
+  amount: z.number().positive('Amount must be positive'),
+  idempotencyKey: z.string().min(1).max(128).optional()
+});
+
+// Buy-in request schema
+export const BuyInRequestSchema = z.object({
+  tableId: z.string().min(1, 'Table ID is required'),
+  amount: z.number().positive('Amount must be positive'),
+  idempotencyKey: z.string().min(1).max(128).optional()
+});
+
+// Cash-out request schema
+export const CashOutRequestSchema = z.object({
+  tableId: z.string().min(1, 'Table ID is required'),
+  chipAmount: z.number().positive('Chip amount must be positive'),
+  idempotencyKey: z.string().min(1).max(128).optional()
 });
 
 // Transaction query params schema

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,7 @@ export * from './error-handling';
 export * from './websocket-utils';
 export * from './chat-moderation';
 export * from './types/statistics';
+export * from './types/idempotency';
 export * from './utils/exhaustive-check';
 
 // Re-export commonly used items for convenience

--- a/packages/shared/src/types/idempotency.ts
+++ b/packages/shared/src/types/idempotency.ts
@@ -1,0 +1,56 @@
+/**
+ * Idempotency key types for preventing duplicate financial transactions
+ */
+
+export interface IdempotencyRecord {
+  key: string;
+  userId: string;
+  action: string;
+  requestHash: string;
+  response: any;
+  status: 'pending' | 'completed' | 'failed';
+  createdAt: Date;
+  expiresAt: Date;
+}
+
+export interface IdempotencyOptions {
+  ttlSeconds?: number; // Default 24 hours (86400 seconds)
+  enableHashValidation?: boolean; // Validate request body hasn't changed
+}
+
+export interface IdempotentRequest {
+  idempotencyKey?: string;
+}
+
+// Extend existing request types with idempotency support
+export interface DepositRequestWithIdempotency {
+  amount: number;
+  method: 'credit_card' | 'bank';
+  idempotencyKey?: string;
+}
+
+export interface WithdrawRequestWithIdempotency {
+  amount: number;
+  method: 'bank' | 'check';
+  idempotencyKey?: string;
+}
+
+export interface TransferRequestWithIdempotency {
+  to_table_id: string;
+  amount: number;
+  idempotencyKey?: string;
+}
+
+export interface BuyInRequestWithIdempotency {
+  tableId: string;
+  playerId: string;
+  amount: number;
+  seatNumber?: number;
+  idempotencyKey?: string;
+}
+
+export interface CashOutRequestWithIdempotency {
+  tableId: string;
+  chipAmount: number;
+  idempotencyKey?: string;
+}


### PR DESCRIPTION
Closes #177

## Summary
Implement idempotency key support to prevent duplicate financial transactions on retries.

## Changes
- Add IdempotencyService with KV storage and 24-hour TTL
- Update all wallet routes to support idempotency keys
- Add request hash validation to detect modified requests
- Return cached responses for duplicate requests
- Add comprehensive test coverage

## Testing
- Unit tests for IdempotencyService
- Integration tests for all wallet operations
- Edge cases: expired keys, concurrent requests, hash validation

Generated with [Claude Code](https://claude.ai/code)